### PR TITLE
[OPS-938] systemd-run plugin

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,13 +1,19 @@
 steps:
   - label: "shellcheck"
     command: "nix-shell --run 'shellcheck hooks/*'"
+    agents:
+      mkaito: true
 
   - label: "test"
     command: "nix-shell --run 'bats tests'"
+    agents:
+      mkaito: true
 
   - wait
 
   - label: run
     command: "echo hello world"
-    plugin:
-      ${BUILDKITE_REPO}#${BUILDKITE_COMMIT}: ~
+    plugins:
+      serokell/systemd-sandbox#${BUILDKITE_COMMIT}: ~
+    agents:
+      mkaito: true

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# systemd sandboxing plugin
+
+This is a Buildkite plugin to wrap your pipelines in a sandboxed transient
+systemd unit that isolates most of the host system and makes excellent
+pancakes.
+
+## Usage
+
+Use in your pipeline as follows:
+
+```yaml
+steps:
+  - label: run a thing
+    command: 'echo hello world'
+    plugins:
+      serokell/systemd-sandboxing#v1.0.0: ~
+```
+
+## Development
+
+A `nix-shell` environment is provided with all dependencies. You can run the
+test suite with `bats tests`, or use the `bk` tool to run the pipeline in
+a local `buildkite-agent`.

--- a/hooks/command
+++ b/hooks/command
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
+
+echo "--- Running ${BUILDKITE_COMMAND} in SystemD sandbox"
+
+CMD_FILE="$(mktemp)"
+cat <<-EOF >| "$CMD_FILE"
+#!/usr/bin/env bash
+set -xe
+
+${BUILDKITE_COMMAND}
+EOF
+chmod +x "$CMD_FILE"
+cat "$CMD_FILE"
+
+function cleanup {
+    rm -f "$CMD_FILE"
+}
+trap cleanup EXIT
+
+sudo systemd-run --quiet --wait --collect --pipe \
+    --property Type=simple --property DynamicUser=true \
+    --property ProtectSystem=strict --property StateDirectory="$BUILDKITE_AGENT_NAME" \
+    --property UMask=077 \
+    --setenv HOME="$BUILDKITE_AGENT_NAME" --setenv PATH="$PATH" --setenv NIX_PATH="${NIX_PATH:-}" \
+        "$CMD_FILE"

--- a/tests/command.bats
+++ b/tests/command.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/env bats
+
+load 'test_helper/bats-support/load'
+load 'test_helper/bats-assert/load'
+
+@test "calls git log" {
+  export BUILDKITE_COMMAND="echo hello world"
+  export BUILDKITE_AGENT_NAME="test"
+
+  run "$PWD/hooks/command"
+
+  assert_output --partial "hello world"
+  assert_success
+}


### PR DESCRIPTION
Doesn't really work yet, but the framework is here. It has a test suite, CI, and the general idea of a command hook. I'll update this PR as I work on it.

The `agents.mkaito = true` thing in the pipeline is to force it to run on my local agent while I fiddle with it.